### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   # ログインしていないユーザーはログインページに促す
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -22,8 +22,7 @@ class ItemsController < ApplicationController
 
   def edit
     # ログインしているユーザーと同一であればeditファイルが読み込まれる
-    if @item.user_id == current_user.id
-    else
+    if @item.user_id != current_user.id
       redirect_to root_path
     end
   end
@@ -31,7 +30,7 @@ class ItemsController < ApplicationController
   def update
     @item.update(item_params)
     # バリデーションがOKであれば詳細画面へ
-    if @item.valid?
+    if @item.update(item_params)
       redirect_to item_path(item_params)
     else
       # NGであれば、エラー内容とデータを保持したままeditファイルを読み込み、エラーメッセージを表示させる
@@ -42,16 +41,15 @@ class ItemsController < ApplicationController
   def show
   end
 
- # def destroy
-  #  @item = Item.find(params[:id])
+  def destroy
     # ログインしているユーザーと同一であればデータを削除する
-  #  if @item.user_id == current_user.id
-   #   @item.destroy
-    #  redirect_to root_path
-   # else
-   #   redirect_to root_path
-   # end
- # end
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if current_user.id == @item.user_id %> 
        <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+       <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     
     <% else %>
      <%# 商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
# What
商品削除機能
# Why
ユーザーは誤って登録した商品を削除できる必要があるため。
商品情報を削除することでデータベースの整合性を維持できる。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/6c9671d2fd8e1363d5da989dd6a84469
